### PR TITLE
Fix: Candle trade sim clobbered strategy state, bump to 1.0.5

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# 1.0.5
+- fix: bug in candle trade simulation where strategy state was clobbered
+
 # 1.0.4
 - docs: create/update
 

--- a/lib/util/simulate_live_candle.js
+++ b/lib/util/simulate_live_candle.js
@@ -10,7 +10,6 @@ module.exports = async (btState = {}, candle = {}) => {
   const { open, high, low, close, vol, mts } = candle
 
   let nextStrategyState = await onCandle(strategy, candle)
-  btState.strategy = nextStrategyState
 
   if (!(vol === 0 || (open === close && high === low && open === high))) {
     const trades = []
@@ -69,7 +68,7 @@ module.exports = async (btState = {}, candle = {}) => {
       trade = trades[i]
       trade.amount = singleTradeAmount
 
-      nextStrategyState = await onTrade(strategy, trade)
+      nextStrategyState = await onTrade(nextStrategyState, trade)
 
       btState.lastPrice = trade.price
       btState.nTrades += 1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-backtest",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "HF backtesting logic module",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
### Description:
When simulating candle trades, the strategy state was clobbered between the `onCandle` and `onTrade` handlers. This fixes it.

### Fixes:
- [x] candle trade simulation

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
