### PR TITLE
 hypercore: add example for hypercore usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ npm-debug.log
 *.swp
 .DS_Store
 package-lock.json
+
+examples/dbs

--- a/examples/hc_stream.js
+++ b/examples/hc_stream.js
@@ -1,0 +1,74 @@
+'use strict'
+
+process.env.DEBUG = '*'
+
+const path = require('path')
+
+const async = require('async')
+const hypercore = require('hypercore')
+
+const { Candle } = require('bfx-api-node-models')
+const { SYMBOLS, TIME_FRAMES } = require('bfx-hf-util')
+const EMAStrategy = require('bfx-hf-strategy/examples/ema_cross')
+
+const { onCandle, onStart, onEnd } = require('../lib//ws_events')
+const initState = require('../lib/init_state')
+
+const hopts = {
+  valueEncoding: 'json',
+  overwrite: true
+}
+
+const rawCandleData = require('./btc_candle_data.json').sort((a, b) => a[0] - b[0])
+const lastCandle = rawCandleData[rawCandleData.length - 1]
+
+const feed = hypercore(path.join(__dirname, 'dbs', 'BTCUSD'), hopts)
+async.forEach(rawCandleData, (el, cb) => {
+  feed.append([el], cb)
+}, (err) => {
+  if (err) throw err
+
+  feed
+    .createReadStream()
+    .on('data', async (data) => {
+      await exec(data)
+    })
+})
+
+// run strategy
+const market = {
+  symbol: SYMBOLS.BTC_USD, // tBTCUSD
+  tf: TIME_FRAMES.ONE_HOUR // 1h
+}
+const strat = EMAStrategy(market)
+
+let btState = initState({
+  strategy: {
+    backtesting: true,
+    ...strat
+  },
+
+  from: null,
+  to: 1533919680000
+})
+
+btState.trades = false
+let first = true
+async function exec (el) {
+  const sc = {
+    ...new Candle(el).toJS(),
+    ...market // attach market data
+  }
+
+  if (first) {
+    first = false
+    btState = await onStart(btState, [null, null, null, el[0], lastCandle[0]])
+  }
+
+  btState = await onCandle(btState, [null, null, null, sc])
+
+  if (sc.mts === lastCandle[0]) {
+    btState = btState = await onEnd(btState)
+    feed.close()
+  }
+}

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "ws": "^6.0.0"
   },
   "devDependencies": {
+    "async": "^3.2.0",
     "babel-eslint": "^7.2.2",
     "babel-loader": "^6.4.1",
     "babel-plugin-lodash": "^3.2.11",
@@ -73,6 +74,7 @@
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^2.0.1",
+    "hypercore": "^9.5.0",
     "istanbul": "^0.4.5",
     "jsdoc-to-markdown": "^5.0.1",
     "mocha": "^6.2.0",


### PR DESCRIPTION
### Description:

this shows how a hypercore can be used for both offline and
online execution of tests. the testdata runs in a stream, which
is memory efficent.

for preparing the hypercore we take the example candles, load
them into a local hypercore and run the example. in practice in
could also be a live streaming connection to an online hypercore,
both works transparently :)

that means, in practice it does not matter if a backtest or even
trading strategy is running online or offline

![Screen Shot 2020-08-03 at 16 43 18](https://user-images.githubusercontent.com/298166/89195056-7c02c600-d5a8-11ea-9a07-7cb33325d47b.png)



### Breaking changes:
- [ ]

### New features:
- [x] hypercore example

### Fixes:
- [ ]

### PR status:
- [ ] Version bumped
- [ ] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
