### PR TITLE
add `manualOnStart` flag

### DIFF
--- a/lib/exec_stream.js
+++ b/lib/exec_stream.js
@@ -18,12 +18,13 @@ const _isTrade = (k, v) => {
  * @param {number|Date} args.from - backtest period start timestamp
  * @param {number|Date} args.to - backtest period end timestamp
  * @param {Function?} args.isTrade - optional, function to detect a trade vs. a candle
+ * @param {Boolean?} args.manualOnStart - optional, use for manual `onStart` calls
  * @param {Function?} progressCallback - optional, called with i/total updates
  */
 
 const execStream = async (strategy = {}, market, args = {}, progressCallback) => {
   const isTrade = args.isTrade || _isTrade
-  const { from, to } = args
+  const { from, to, manualOnStart } = args // FIXME: remove `manualOnStart` in 2.0
 
   const btState = initState({
     strategy: {
@@ -37,13 +38,19 @@ const execStream = async (strategy = {}, market, args = {}, progressCallback) =>
 
   btState.trades = false
 
-  const exec = getExec(market, btState, from, to, isTrade, progressCallback)
+  const exec = getExec({
+    market, btState, from, to, isTrade, progressCallback, manualOnStart
+  })
 
-  return { exec, btState, onEnd }
+  return { exec, btState, onEnd, onStart }
 }
 
-function getExec (market, btState, from, to, isTrade, progressCallback) {
-  const opts = { first: true }
+function getExec (conf) {
+  let {
+    market, btState, from, to, isTrade, progressCallback, manualOnStart
+  } = conf
+
+  const opts = manualOnStart ? { first: false } : { first: true }
   let count = 0
 
   return async function (k, el) {


### PR DESCRIPTION
the current honey framework is usually running `onStart` and
`onEnd` callbacks for the user. this was useful, but with streams
we need more fine grained control. additionally the requirements
of the ui have grown.

this adds a flag for backwards compat that allows the user to call
`onStart` manually. it is hidden behind a flag for backwards
compat. with 2.0 we will remove that flag.

it is useful in these scenarios: we have multiple streams, e.g.
stream a, b and c. we want to run the same strategy on all three
input types, but the current framework would call `onStart` for
all of them.
