### PR TITLE
breaking change: fix candle handling, don't emit emulated trades

### DIFF
--- a/lib/util/simulate_live_candle.js
+++ b/lib/util/simulate_live_candle.js
@@ -3,7 +3,6 @@
 const { onCandle, onTrade } = require('bfx-hf-strategy')
 
 const N_TRADES = 5
-const DUST = 0.0000001
 
 module.exports = async (btState = {}, candle = {}) => {
   const { strategy } = btState
@@ -29,7 +28,7 @@ module.exports = async (btState = {}, candle = {}) => {
 
     while (true) {
       // Handle hitting high point (go to low, or close)
-      if (!highReached && Math.abs(currPrice - high) < DUST) {
+      if (!highReached) {
         dir *= -1
         highReached = true
         priceStep = lowReached
@@ -37,13 +36,13 @@ module.exports = async (btState = {}, candle = {}) => {
           : high === low ? 0 : (high - low) / N_TRADES // go to low
 
       // Handle hitting low point (go to high, or close)
-      } else if (!lowReached && Math.abs(currPrice - low) < DUST) {
+      } else if (!lowReached) {
         dir *= -1
         lowReached = true
         priceStep = highReached
           ? close === low ? 0 : (close - low) / N_TRADES // go to close
           : high === low ? 0 : (high - low) / N_TRADES // go to high
-      } else if (highReached && lowReached && Math.abs(currPrice - close) < DUST) {
+      } else if (highReached && lowReached) {
         break
       }
 

--- a/lib/util/simulate_live_candle.js
+++ b/lib/util/simulate_live_candle.js
@@ -1,79 +1,11 @@
 'use strict'
 
-const { onCandle, onTrade } = require('bfx-hf-strategy')
-
-const N_TRADES = 5
+const { onCandle } = require('bfx-hf-strategy')
 
 module.exports = async (btState = {}, candle = {}) => {
   const { strategy } = btState
-  const { open, high, low, close, vol, mts } = candle
 
-  let nextStrategyState = await onCandle(strategy, candle)
-
-  if (!(vol === 0 || (open === close && high === low && open === high))) {
-    const trades = []
-    let dir = Math.random() > 0.5 ? 1 : -1
-    let highReached = open === high
-    let lowReached = open === low
-    let currPrice = open
-    let priceStep = dir === 1 // go to high or low
-      ? high === open ? 0 : (high - open) / N_TRADES
-      : open === low ? 0 : (open - low) / N_TRADES
-
-    trades.push({
-      amount: 0,
-      price: currPrice,
-      mts
-    })
-
-    while (true) {
-      // Handle hitting high point (go to low, or close)
-      if (!highReached) {
-        dir *= -1
-        highReached = true
-        priceStep = lowReached
-          ? high === close ? 0 : (high - close) / N_TRADES // go to close
-          : high === low ? 0 : (high - low) / N_TRADES // go to low
-
-      // Handle hitting low point (go to high, or close)
-      } else if (!lowReached) {
-        dir *= -1
-        lowReached = true
-        priceStep = highReached
-          ? close === low ? 0 : (close - low) / N_TRADES // go to close
-          : high === low ? 0 : (high - low) / N_TRADES // go to high
-      } else if (highReached && lowReached) {
-        break
-      }
-
-      if (priceStep === 0) {
-        break
-      }
-
-      currPrice += priceStep * dir
-
-      trades.push({
-        amount: 0, // set evenly at the end
-        price: +currPrice.toFixed(7), // starts with open
-        mts
-      })
-    }
-
-    // Set trade amounts & pass to strategy
-    const singleTradeAmount = vol / trades.length
-    let trade
-
-    for (let i = 0; i < trades.length; i += 1) {
-      trade = trades[i]
-      trade.amount = singleTradeAmount
-
-      nextStrategyState = await onTrade(nextStrategyState, trade)
-
-      btState.lastPrice = trade.price
-      btState.nTrades += 1
-      btState.strategy = nextStrategyState
-    }
-  }
+  const nextStrategyState = await onCandle(strategy, candle)
 
   return nextStrategyState
 }

--- a/test/backtest-offline.js
+++ b/test/backtest-offline.js
@@ -17,7 +17,7 @@ describe('basic', () => {
     const state = await execOffline(strategy, args)
 
     const { trades } = state.strategy
-    assert.strictEqual(trades.length, 14)
+    assert.strictEqual(trades.length, 8)
 
     const { fees, pl, prices } = trades.reduce((acc, el) => {
       acc.pl += el.pl
@@ -27,18 +27,15 @@ describe('basic', () => {
       return acc
     }, { fees: 0, pl: 0, prices: [] })
 
-    assert.strictEqual(fees, 1103.4021953382398)
-    assert.strictEqual(pl, -5370.304526218242)
+    assert.strictEqual(fees, 633.102)
+    assert.strictEqual(pl, -1672.102)
     assert.deepStrictEqual(
       prices,
       [
         39130, 38844,
-        37910, 39600,
-        39657, 38844,
-        38888.09766912, 39415,
-        39560, 38734,
-        39163, 40650,
-        39972, 41334
+        39600, 38844,
+        39415, 38734,
+        40650, 41334
       ]
     )
   })
@@ -62,11 +59,11 @@ describe('basic', () => {
       return acc
     }, { fees: 0, pl: 0, prices: [] })
 
-    assert.strictEqual(fees, 12.77324954092)
-    assert.strictEqual(pl, -39.73275680092024)
+    assert.strictEqual(fees, 12.772849540920001)
+    assert.strictEqual(pl, -39.93235680092029)
     assert.deepStrictEqual(
       prices,
-      [1075.09213886, 1056.9326316, 1049.3, 1067.4, 1064.3, 1073.6]
+      [1075.09213886, 1056.9326316, 1049.1, 1067.4, 1064.3, 1073.6]
     )
   })
 })


### PR DESCRIPTION
the initial reason for this PR was a memleak we are running into with very small prices, e.g. with ADA/BTC. see 
f8ccc1d, part of this PR

in general it uncovered a section of code which was doing something unexpected:

the current backtesting code takes a candle and tries to create
a few trades from it, to "reverse engineer" the trades during that
candle period. it tires to calculate the trades that lead to the
current candle, and then submits them into the strategy that is
run.

1. this comes as a surprise when you have chosen candles as an
input source (and opted out of trades), because the backtester
will try to sample trades and run the `onTrade` handlers which
influence the result. this is a major difference to the live
execution of a strategy in the HF (`bfx-hf-exec-strategy`)

2. the used sampling / emulation was never accurate. it tried to
use a static minimum amount for calculating the bonds for the upper
and lower prices, but with heavy price fluctuations and different
prices between trading pairs (i.e. ADA/BTC) this does not make
sense. also depending on the strategy volumes and other values
might be important, by sampling them we disturb the creation of
accurate results. an example was the trade amount which was set
evenly to the same amount between all emulated trades

the current change makes backtesting on candles more predictable and introduces a clear separation of candles and trade data also in backtests.

---

for reference, here is the way we execute a live strategy. trades are clearly separated from the candles: https://github.com/bitfinexcom/bfx-hf-strategy-exec/blob/f24c02812f95264bf44e509a49c014dfc28b9459/index.js#L141-L150


when not in backtest, we use onCandles directly, again, clear separation from trades and no emulation fo trades: https://github.com/bitfinexcom/bfx-hf-strategy/blob/0d121ef6f7bd47e62d2a1e15123b8affd6f9a6af/lib/updates/on_candle.js
