### PR TITLE
Capture error when draining data

### DIFF
--- a/lib/exec_offline.js
+++ b/lib/exec_offline.js
@@ -97,7 +97,13 @@ const execOffline = async (strategy = {}, args = {}) => {
     }
 
     isDraining = true
-    btState = await drainDataPoints(context, dataPointFeed, btState)
+
+    try {
+      btState = await drainDataPoints(context, dataPointFeed, btState)
+    } catch (err) {
+      return reject(err)
+    }
+
     isDraining = false
 
     if (dataPointFeed.closed) {


### PR DESCRIPTION
### Description:
This caused errors to be swallowed by the backtest and not be reported to the UI

related to: https://app.asana.com/0/1201848935859401/1202411888197018/f