### PR TITLE
Skip indicators reset before backtest execution

### DIFF
--- a/lib/exec_offline.js
+++ b/lib/exec_offline.js
@@ -50,7 +50,15 @@ const execOffline = async (strategy = {}, args = {}) => {
     context,
     dataPointFeed,
     reportError,
-    reportProgress
+    reportProgress,
+    margin,
+    isDerivative,
+    maxLeverage,
+    useMaxLeverage,
+    increaseLeverage,
+    leverage,
+    addStopOrder,
+    stopOrderPercent
   } = args
 
   let watchers = []
@@ -68,7 +76,15 @@ const execOffline = async (strategy = {}, args = {}) => {
   let btState = initState({
     strategy: {
       backtesting: true,
-      ...strategy
+      ...strategy,
+      margin,
+      isDerivative,
+      maxLeverage,
+      useMaxLeverage,
+      increaseLeverage,
+      leverage,
+      addStopOrder,
+      stopOrderPercent
     },
     from: start,
     to: end,

--- a/lib/exec_offline.js
+++ b/lib/exec_offline.js
@@ -92,7 +92,7 @@ const execOffline = async (strategy = {}, args = {}) => {
   })
 
   btState.trades = includeTrades
-  btState = await onStart(btState, [null, null, null, start, end])
+  btState = await onStart(btState, [null, null, null, start, end], false, false)
 
   if (startPerformanceWatchers) {
     watchers = startPerformanceWatchers(perfManager, abortStrategy, constraints)

--- a/lib/ws_events/on_start.js
+++ b/lib/ws_events/on_start.js
@@ -13,7 +13,7 @@ const debug = require('../util/debug')
  * @param {boolean} isPrimary
  * @return {Object} nextBtState
  */
-module.exports = async (btState = {}, msg = [], isPrimary = false) => {
+module.exports = async (btState = {}, msg = [], isPrimary = false, shouldResetIndicators = true) => {
   const { strategy = {} } = btState
   const { onStart } = strategy
   const [,,, from, to] = msg
@@ -26,7 +26,7 @@ module.exports = async (btState = {}, msg = [], isPrimary = false) => {
     )
   }
 
-  resetIndicators(strategy)
+  if (shouldResetIndicators) { resetIndicators(strategy) }
 
   let strategyState = strategy
 


### PR DESCRIPTION
Skip indicators reset before backtest execution to retain seed candles